### PR TITLE
only return status code to later be used as a lookup key

### DIFF
--- a/securedrop_export/export.py
+++ b/securedrop_export/export.py
@@ -121,19 +121,16 @@ class SDExport(object):
         solutions for mimetype handling, which we want to avoid.
         """
         sys.stderr.write(msg)
-        sys.stderr.write("\n")
         logger.info('Exiting with message: {}'.format(msg))
         if e:
             try:
                 # If the file archive was extracted, delete before returning
                 if os.path.isdir(self.tmpdir):
                     shutil.rmtree(self.tmpdir)
-                e_output = e.output
-                logger.error(e_output)
+                logger.error(e.output)
             except Exception:
-                e_output = "<unknown exception>"
-            sys.stderr.write(e_output)
-            sys.stderr.write("\n")
+                logger.error("<unknown exception>")
+
         # exit with 0 return code otherwise the os will attempt to open
         # the file with another application
         sys.exit(0)


### PR DESCRIPTION
## Description

Since we display the status code to the user (e.g. `ERROR_USB_MOUNT`, `ERROR_USB_WRITE`, `ERROR_PRINT`, `ERROR_PRINTER_URI`, etc.) we want to make sure there isn't a bunch of text appended. Now that logging has been added to the export script, we just (1) log the exception, (2) return error status code to the client