### PR TITLE
General improvements to securedrop-export

### DIFF
--- a/securedrop_export/export.py
+++ b/securedrop_export/export.py
@@ -167,20 +167,19 @@ class SDExport(object):
         since non-zero exit values will cause system to try alternative
         solutions for mimetype handling, which we want to avoid.
         """
-        sys.stderr.write(msg)
-        sys.stderr.write("\n")
         logger.info('Exiting with message: {}'.format(msg))
-        if e:
+        if not e:
+            sys.stderr.write(msg)
+            sys.stderr.write("\n")
+        else:
             try:
                 # If the file archive was extracted, delete before returning
                 if os.path.isdir(self.tmpdir):
                     shutil.rmtree(self.tmpdir)
-                e_output = e.output
-                logger.error(e_output)
-            except Exception:
-                e_output = "<unknown exception>"
-            sys.stderr.write(str(e_output))
-            sys.stderr.write("\n")
+                logger.error("{}:{}".format(msg, e.output))
+            except Exception as ex:
+                logger.error("Unhandled exception: {}".format(ex))
+                sys.stderr.write(ExportStatus.ERROR_GENERIC.value)
         # exit with 0 return code otherwise the os will attempt to open
         # the file with another application
         sys.exit(0)

--- a/securedrop_export/export.py
+++ b/securedrop_export/export.py
@@ -137,19 +137,6 @@ class SDExport(object):
         )
         self.tmpdir = tempfile.mkdtemp()
 
-        try:
-            with open(config_path) as f:
-                logging.info('Retrieving VM configuration')
-                json_config = json.loads(f.read())
-                self.pci_bus_id = json_config.get("pci_bus_id", None)
-                logging.info('pci_bus_id is {}'.format(self.pci_bus_id))
-                if self.pci_bus_id is None:
-                    logging.error('pci_bus_id is not set in VM configuration')
-                    raise
-        except Exception:
-            logger.error("error parsing VM configuration.")
-            self.exit_gracefully(ExportStatus.ERROR_USB_CONFIGURATION.value)
-
     def safe_check_call(self, command, error_message):
         """
         Safely wrap subprocess.check_output to ensure we always return 0 and

--- a/securedrop_export/export.py
+++ b/securedrop_export/export.py
@@ -226,12 +226,12 @@ class SDExport(object):
             partition_count = device_and_partitions.decode('utf-8').split('\n').count('part')
             if partition_count > 1:
                 logging.debug("multiple partitions not supported")
-                self.exit_gracefully(ExportStatus.USB_ENCRYPTION_NOT_SUPPORTED)
+                self.exit_gracefully(ExportStatus.USB_ENCRYPTION_NOT_SUPPORTED.value)
 
             # set device to /dev/sda if disk is encrypted, /dev/sda1 if partition encrypted
             self.device = DEVICE if partition_count == 0 else DEVICE + '1'
         except subprocess.CalledProcessError:
-            self.exit_gracefully(ExportStatus.USB_ENCRYPTION_NOT_SUPPORTED)
+            self.exit_gracefully(ExportStatus.USB_ENCRYPTION_NOT_SUPPORTED.value)
 
     def check_luks_volume(self):
         # cryptsetup isLuks returns 0 if the device is a luks volume

--- a/securedrop_export/export.py
+++ b/securedrop_export/export.py
@@ -203,8 +203,7 @@ class SDExport(object):
             with tarfile.open(self.archive) as tar:
                 tar.extractall(self.tmpdir)
         except Exception:
-            msg = ExportStatus.ERROR_EXTRACTION.value
-            self.exit_gracefully(msg)
+            self.exit_gracefully(ExportStatus.ERROR_EXTRACTION.value)
 
     def check_usb_connected(self):
         # If the USB is not attached via qvm-usb attach, lsusb will return empty string and a
@@ -271,8 +270,7 @@ class SDExport(object):
                 rc = p.returncode
                 if rc != 0:
                     logging.error('Bad phassphrase for {}'.format(self.encrypted_device))
-                    msg = ExportStatus.USB_BAD_PASSPHRASE.value
-                    self.exit_gracefully(msg)
+                    self.exit_gracefully(ExportStatus.USB_BAD_PASSPHRASE.value)
         except subprocess.CalledProcessError:
             self.exit_gracefully(ExportStatus.USB_ENCRYPTION_NOT_SUPPORTED)
 
@@ -308,8 +306,7 @@ class SDExport(object):
             logging.info('File copied successfully to {}'.format(self.target_dirname))
             self.popup_message("Files exported successfully to disk.")
         except (subprocess.CalledProcessError, OSError):
-            msg = ExportStatus.ERROR_USB_WRITE.value
-            self.exit_gracefully(msg)
+            self.exit_gracefully(ExportStatus.ERROR_USB_WRITE.value)
         finally:
             # Finally, we sync the filesystem, unmount the drive and lock the
             # luks volume, and exit 0
@@ -341,12 +338,10 @@ class SDExport(object):
                 else:
                     time.sleep(5)
             except subprocess.CalledProcessError:
-                msg = ExportStatus.ERROR_PRINT.value
-                self.exit_gracefully(msg)
+                self.exit_gracefully(ExportStatus.ERROR_PRINT.value)
             except TimeoutException:
                 logging.error('Timeout waiting for printer {}'.format(self.printer_name))
-                msg = ExportStatus.ERROR_PRINT.value
-                self.exit_gracefully(msg)
+                self.exit_gracefully(ExportStatus.ERROR_PRINT.value)
         return True
 
     def get_printer_uri(self):
@@ -355,8 +350,7 @@ class SDExport(object):
         try:
             output = subprocess.check_output(["sudo", "lpinfo", "-v"])
         except subprocess.CalledProcessError:
-            msg = ExportStatus.ERROR_PRINTER_URI.value
-            self.exit_gracefully(msg)
+            self.exit_gracefully(ExportStatus.ERROR_PRINTER_URI.value)
 
         # fetch the usb printer uri
         for line in output.split():

--- a/securedrop_export/main.py
+++ b/securedrop_export/main.py
@@ -1,6 +1,7 @@
 import logging
 
 from securedrop_export import export
+from securedrop_export.export import ExportStatus
 
 logger = logging.getLogger(__name__)
 
@@ -11,7 +12,7 @@ def __main__(submission):
     try:
         submission.archive_metadata = export.Metadata(submission.tmpdir)
     except Exception:
-        submission.exit_gracefully("ERROR_METADATA_PARSING")
+        submission.exit_gracefully(ExportStatus.ERROR_METADATA_PARSING.value)
 
     if submission.archive_metadata.is_valid():
         if submission.archive_metadata.export_method == "usb-test":
@@ -47,4 +48,4 @@ def __main__(submission):
             submission.setup_printer(printer_uri, printer_ppd)
             submission.print_test_page()
     else:
-        submission.exit_gracefully("ERROR_ARCHIVE_METADATA")
+        submission.exit_gracefully(ExportStatus.ERROR_ARCHIVE_METADATA.value)

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -20,41 +20,6 @@ BAD_TEST_CONFIG = os.path.join(os.path.dirname(__file__), "sd-export-config-bad.
 ANOTHER_BAD_TEST_CONFIG = os.path.join(os.path.dirname(__file__), "sd-export-config-bad-2.json")
 
 
-def test_bad_sd_export_config_invalid_json(capsys):
-
-    expected_message = "ERROR_USB_CONFIGURATION"
-    assert export.ExportStatus.ERROR_USB_CONFIGURATION.value == expected_message
-
-    with pytest.raises(SystemExit) as sysexit:
-        export.SDExport("", BAD_TEST_CONFIG)
-    # A graceful exit means a return code of 0
-    assert sysexit.value.code == 0
-
-    captured = capsys.readouterr()
-    assert captured.err == "{}\n".format(expected_message)
-    assert captured.out == ""
-
-
-def test_bad_sd_export_config_invalid_value(capsys):
-
-    expected_message = "ERROR_USB_CONFIGURATION"
-    assert export.ExportStatus.ERROR_USB_CONFIGURATION.value == expected_message
-
-    with pytest.raises(SystemExit) as sysexit:
-        export.SDExport("", ANOTHER_BAD_TEST_CONFIG)
-    # A graceful exit means a return code of 0
-    assert sysexit.value.code == 0
-
-    captured = capsys.readouterr()
-    assert captured.err == "{}\n".format(expected_message)
-    assert captured.out == ""
-
-
-def test_good_sd_export_config(capsys):
-    submission = export.SDExport("", TEST_CONFIG)
-    assert submission.pci_bus_id == "2"
-
-
 def test_exit_gracefully_no_exception(capsys):
 
     submission = export.SDExport("testfile", TEST_CONFIG)

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -299,3 +299,16 @@ def test_luks_precheck_encrypted(mocked_call, capsys):
     assert sysexit.value.code == 0
     captured = capsys.readouterr()
     assert captured.err == "{}\n".format(expected_message)
+
+
+def test_safe_check_call(capsys):
+    submission = export.SDExport("testfile", TEST_CONFIG)
+    submission.safe_check_call(['ls'], "this will work")
+    mocked_exit = mock.patch("export.exit_gracefully", return_value=0)
+    expected_message = "uh oh!!!!"
+    with pytest.raises(SystemExit) as sysexit:
+        submission.safe_check_call(['ls', 'kjdsfhkdjfh'], expected_message)
+        mocked_exit.assert_called_once_with(expected_message)
+    assert sysexit.value.code == 0
+    captured = capsys.readouterr()
+    assert captured.err == "{}\n".format(expected_message)

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -22,7 +22,9 @@ ANOTHER_BAD_TEST_CONFIG = os.path.join(os.path.dirname(__file__), "sd-export-con
 
 def test_bad_sd_export_config_invalid_json(capsys):
 
-    expected_message = "ERROR_CONFIG"
+    expected_message = "ERROR_USB_CONFIGURATION"
+    assert export.ExportStatus.ERROR_USB_CONFIGURATION.value == expected_message
+
     with pytest.raises(SystemExit) as sysexit:
         export.SDExport("", BAD_TEST_CONFIG)
     # A graceful exit means a return code of 0
@@ -35,7 +37,9 @@ def test_bad_sd_export_config_invalid_json(capsys):
 
 def test_bad_sd_export_config_invalid_value(capsys):
 
-    expected_message = "ERROR_CONFIG"
+    expected_message = "ERROR_USB_CONFIGURATION"
+    assert export.ExportStatus.ERROR_USB_CONFIGURATION.value == expected_message
+
     with pytest.raises(SystemExit) as sysexit:
         export.SDExport("", ANOTHER_BAD_TEST_CONFIG)
     # A graceful exit means a return code of 0
@@ -170,6 +174,7 @@ def test_get_good_printer_uri(mocked_call):
 def test_get_bad_printer_uri(mocked_call, capsys):
     submission = export.SDExport("testfile", TEST_CONFIG)
     expected_message = "ERROR_PRINTER_NOT_FOUND"
+    assert export.ExportStatus.ERROR_PRINTER_NOT_FOUND.value == expected_message
     mocked_exit = mock.patch("export.exit_gracefully", return_value=0)
 
     with pytest.raises(SystemExit) as sysexit:
@@ -208,6 +213,7 @@ def test_is_not_open_office_file(capsys, open_office_paths):
 def test_usb_precheck_disconnected(capsys):
     submission = export.SDExport("testfile", TEST_CONFIG)
     expected_message = "USB_NOT_CONNECTED"
+    assert export.ExportStatus.USB_NOT_CONNECTED.value == expected_message
     mocked_exit = mock.patch("export.exit_gracefully", return_value=0)
 
     mock.patch("subprocess.check_output", return_value=CalledProcessError(1, 'check_output'))
@@ -225,6 +231,7 @@ def test_usb_precheck_disconnected(capsys):
 def test_usb_precheck_connected(mocked_call, capsys):
     submission = export.SDExport("testfile", TEST_CONFIG)
     expected_message = "USB_CONNECTED"
+    assert export.ExportStatus.USB_CONNECTED.value == expected_message
     mocked_exit = mock.patch("export.exit_gracefully", return_value=0)
     with pytest.raises(SystemExit) as sysexit:
         submission.check_usb_connected()
@@ -238,7 +245,7 @@ def test_usb_precheck_connected(mocked_call, capsys):
 @mock.patch("subprocess.check_output", return_value=SAMPLE_OUTPUT_NO_PART)
 def test_luks_precheck_encrypted(mocked_call, capsys):
     submission = export.SDExport("testfile", TEST_CONFIG)
-    expected_message = "USB_ENCRYPTED"
+    expected_message = export.ExportStatus.USB_ENCRYPTED.value
     mocked_exit = mock.patch("export.exit_gracefully", return_value=0)
 
     with pytest.raises(SystemExit) as sysexit:
@@ -252,7 +259,7 @@ def test_luks_precheck_encrypted(mocked_call, capsys):
 @mock.patch("subprocess.check_output", return_value=SAMPLE_OUTPUT_ONE_PART)
 def test_luks_precheck_encrypted(mocked_call, capsys):
     submission = export.SDExport("testfile", TEST_CONFIG)
-    expected_message = "USB_ENCRYPTED"
+    expected_message = export.ExportStatus.USB_ENCRYPTED.value
     mocked_exit = mock.patch("export.exit_gracefully", return_value=0)
 
     with pytest.raises(SystemExit) as sysexit:
@@ -266,7 +273,7 @@ def test_luks_precheck_encrypted(mocked_call, capsys):
 @mock.patch("subprocess.check_output", return_value=SAMPLE_OUTPUT_MULTI_PART)
 def test_luks_precheck_encrypted(mocked_call, capsys):
     submission = export.SDExport("testfile", TEST_CONFIG)
-    expected_message = "USB_NO_SUPPORTED_ENCRYPTION"
+    expected_message = export.ExportStatus.USB_ENCRYPTION_NOT_SUPPORTED.value
     mocked_exit = mock.patch("export.exit_gracefully", return_value=0)
 
     with pytest.raises(SystemExit) as sysexit:
@@ -276,10 +283,12 @@ def test_luks_precheck_encrypted(mocked_call, capsys):
     captured = capsys.readouterr()
     assert captured.err == "{}\n".format(expected_message)
 
+
 @mock.patch("subprocess.check_output", return_value=SAMPLE_OUTPUT_ONE_PART)
 def test_luks_precheck_encrypted(mocked_call, capsys):
     submission = export.SDExport("testfile", TEST_CONFIG)
-    expected_message = "USB_NO_SUPPORTED_ENCRYPTION"
+    expected_message = "USB_ENCRYPTION_NOT_SUPPORTED"
+    assert expected_message == export.ExportStatus.USB_ENCRYPTION_NOT_SUPPORTED.value
     mocked_exit = mock.patch("export.exit_gracefully", return_value=0)
 
     mock.patch("subprocess.check_call", return_value=CalledProcessError(1, 'check_call'))

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -243,21 +243,36 @@ def test_usb_precheck_connected(mocked_call, capsys):
 
 
 @mock.patch("subprocess.check_output", return_value=SAMPLE_OUTPUT_NO_PART)
-def test_luks_precheck_encrypted(mocked_call, capsys):
+def test_extract_device_name_no_part(mocked_call, capsys):
     submission = export.SDExport("testfile", TEST_CONFIG)
-    expected_message = export.ExportStatus.USB_ENCRYPTED.value
-    mocked_exit = mock.patch("export.exit_gracefully", return_value=0)
-
-    with pytest.raises(SystemExit) as sysexit:
-        submission.check_luks_volume()
-        mocked_exit.assert_called_once_with(expected_message)
-    assert sysexit.value.code == 0
-    captured = capsys.readouterr()
-    assert captured.err == "{}\n".format(expected_message)
+    submission.set_extracted_device_name()
+    assert submission.device == "/dev/sda"
 
 
 @mock.patch("subprocess.check_output", return_value=SAMPLE_OUTPUT_ONE_PART)
-def test_luks_precheck_encrypted(mocked_call, capsys):
+def test_extract_device_name_single_part(mocked_call, capsys):
+    submission = export.SDExport("testfile", TEST_CONFIG)
+    submission.set_extracted_device_name()
+    assert submission.device == "/dev/sda1"
+
+
+@mock.patch("subprocess.check_output", return_value=SAMPLE_OUTPUT_MULTI_PART)
+def test_extract_device_name_multiple_part(mocked_call, capsys):
+    submission = export.SDExport("testfile", TEST_CONFIG)
+    mocked_exit = mock.patch("export.exit_gracefully", return_value=0)
+    expected_message = export.ExportStatus.USB_ENCRYPTION_NOT_SUPPORTED.value
+
+    with pytest.raises(SystemExit) as sysexit:
+        submission.set_extracted_device_name()
+        mocked_exit.assert_called_once_with(expected_message)
+    assert sysexit.value.code == 0
+    captured = capsys.readouterr()
+    assert captured.err == "{}\n".format(expected_message)
+
+
+@mock.patch("subprocess.check_output", return_value=SAMPLE_OUTPUT_NO_PART)
+@mock.patch("subprocess.check_call", return_value=0)
+def test_luks_precheck_encrypted_fde(mocked_call, capsys):
     submission = export.SDExport("testfile", TEST_CONFIG)
     expected_message = export.ExportStatus.USB_ENCRYPTED.value
     mocked_exit = mock.patch("export.exit_gracefully", return_value=0)
@@ -266,12 +281,23 @@ def test_luks_precheck_encrypted(mocked_call, capsys):
         submission.check_luks_volume()
         mocked_exit.assert_called_once_with(expected_message)
     assert sysexit.value.code == 0
-    captured = capsys.readouterr()
-    assert captured.err == "{}\n".format(expected_message)
+
+
+@mock.patch("subprocess.check_output", return_value=SAMPLE_OUTPUT_ONE_PART)
+@mock.patch("subprocess.check_call", return_value=0)
+def test_luks_precheck_encrypted_single_part(mocked_call, capsys):
+    submission = export.SDExport("testfile", TEST_CONFIG)
+    expected_message = export.ExportStatus.USB_ENCRYPTED.value
+    mocked_exit = mock.patch("export.exit_gracefully", return_value=0)
+
+    with pytest.raises(SystemExit) as sysexit:
+        submission.check_luks_volume()
+        mocked_exit.assert_called_once_with(expected_message)
+    assert sysexit.value.code == 0
 
 
 @mock.patch("subprocess.check_output", return_value=SAMPLE_OUTPUT_MULTI_PART)
-def test_luks_precheck_encrypted(mocked_call, capsys):
+def test_luks_precheck_encrypted_multi_part(mocked_call, capsys):
     submission = export.SDExport("testfile", TEST_CONFIG)
     expected_message = export.ExportStatus.USB_ENCRYPTION_NOT_SUPPORTED.value
     mocked_exit = mock.patch("export.exit_gracefully", return_value=0)
@@ -285,7 +311,7 @@ def test_luks_precheck_encrypted(mocked_call, capsys):
 
 
 @mock.patch("subprocess.check_output", return_value=SAMPLE_OUTPUT_ONE_PART)
-def test_luks_precheck_encrypted(mocked_call, capsys):
+def test_luks_precheck_encrypted_luks_error(mocked_call, capsys):
     submission = export.SDExport("testfile", TEST_CONFIG)
     expected_message = "USB_ENCRYPTION_NOT_SUPPORTED"
     assert expected_message == export.ExportStatus.USB_ENCRYPTION_NOT_SUPPORTED.value

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -84,7 +84,7 @@ def test_exit_gracefully_exception(capsys):
     assert sysexit.value.code == 0
 
     captured = capsys.readouterr()
-    assert captured.err == "{}\n<unknown exception>\n".format(test_msg)
+    assert captured.err == export.ExportStatus.ERROR_GENERIC.value
     assert captured.out == ""
 
 


### PR DESCRIPTION
### Description
Closes #15 
Provides improvements:
- wrap check_call to ensure exceptions are more reliably caught
- use enum to specify error codes
- fix some tests/regressions previously introduced (by decoupling tests for `set_extracted_device_name()` and `check_luks()`)

### Test plan

- [ ] Export works in Qubes using the client:
- build package on this branch
- install to sd-export-usb-template (or sd-export-usb when it's running)
- test export functionality