### PR TITLE
Remove notify-send notification in securedrop-export

### DIFF
--- a/securedrop_export/disk/actions.py
+++ b/securedrop_export/disk/actions.py
@@ -171,7 +171,6 @@ class DiskAction(ExportAction):
             logger.info('Copying file to {}'.format(self.submission.target_dirname))
             subprocess.check_call(["cp", "-r", export_data, target_path])
             logger.info('File copied successfully to {}'.format(self.submission.target_dirname))
-            self.submission.popup_message("Files exported successfully to disk.")
         except (subprocess.CalledProcessError, OSError):
             self.submission.exit_gracefully(ExportStatus.ERROR_USB_WRITE.value)
         finally:

--- a/securedrop_export/export.py
+++ b/securedrop_export/export.py
@@ -125,19 +125,6 @@ class SDExport(object):
         except subprocess.CalledProcessError as ex:
             self.exit_gracefully(msg=error_message, e=ex.output)
 
-    def popup_message(self, msg: str):
-        self.safe_check_call(
-            command=[
-                "notify-send",
-                "--expire-time",
-                "3000",
-                "--icon",
-                "/usr/share/securedrop/icons/sd-logo.png",
-                "SecureDrop: {}".format(msg),
-            ],
-            error_message="Error sending notification:"
-        )
-
 
 class ExportAction(abc.ABC):
     """

--- a/securedrop_export/print/actions.py
+++ b/securedrop_export/print/actions.py
@@ -149,7 +149,6 @@ class PrintAction(ExportAction):
     def print_test_page(self):
         logger.info('Printing test page')
         self.print_file("/usr/share/cups/data/testprint")
-        self.submission.popup_message("Printing test page")
 
     def print_all_files(self):
         files_path = os.path.join(self.submission.tmpdir, "export_data/")
@@ -159,8 +158,7 @@ class PrintAction(ExportAction):
             file_path = os.path.join(files_path, f)
             self.print_file(file_path)
             print_count += 1
-            msg = "Printing document {} of {}".format(print_count, len(files))
-            self.submission.popup_message(msg)
+            logger.info("Printing document {} of {}".format(print_count, len(files)))
 
     def is_open_office_file(self, filename):
         OPEN_OFFICE_FORMATS = [

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 import os
 import pytest
 import subprocess  # noqa: F401
@@ -116,18 +114,6 @@ def test_valid_encryption_config(capsys):
     assert config.encryption_key == "hunter1"
     assert config.encryption_method == "luks"
     assert config.is_valid()
-
-
-@mock.patch("subprocess.check_call")
-def test_popup_message(mocked_call):
-    submission = export.SDExport("testfile", TEST_CONFIG)
-    submission.popup_message("hello!")
-    mocked_call.assert_called_once_with([
-        "notify-send",
-        "--expire-time", "3000",
-        "--icon", "/usr/share/securedrop/icons/sd-logo.png",
-        "SecureDrop: hello!"
-    ])
 
 
 def test_safe_check_call(capsys, mocker):


### PR DESCRIPTION
Towards #37  
Since we are now logging and aggregating logs, and that we are disabling notifications, this code is no longer required.

https://github.com/freedomofpress/securedrop-debian-packaging/pull/122 will disable notifications at at the system level, therefore these notifications should no longer be used.