### PR TITLE
logging audit

### DIFF
--- a/securedrop_export/print/actions.py
+++ b/securedrop_export/print/actions.py
@@ -197,7 +197,7 @@ class PrintAction(ExportAction):
             )
             file_to_print = converted_path
 
-        logger.info('Sending file to printer {}:{}'.format(self.printer_name, file_to_print))
+        logger.info('Sending file to printer {}'.format(self.printer_name))
         self.submission.safe_check_call(
             command=["xpp", "-P", self.printer_name, file_to_print],
             error_message=ExportStatus.ERROR_PRINT.value


### PR DESCRIPTION
Towards https://github.com/freedomofpress/securedrop-workstation/issues/397

I interactively ran through USB export and printing in Qubes on this wee diff to make sure we're not logging any: passphrases or files of original source documents. Bonus points for doing the same but otherwise just scanning through the log lines yourself is sufficient. 