### PR TITLE
If user has manually unlocked USB drive, don't re-prompt for pasphrase

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ The supported device types for export are as follows, including the possible err
 
 2. `disk-test`: Preflight check that checks for LUKS-encrypted volume that returns:
     - `USB_ENCRYPTED` if a LUKS volume is attached to sd-devices
+    - `USB_ENCRYPTED_UNLOCKED` if an unlocked LUKS volume is attached to sd-devices (this means the drive was unlocked manually by the user)
     - `USB_ENCRYPTION_NOT_SUPPORTED` if a LUKS volume is not attached or there was any other error
     - `USB_DISK_ERROR`
 

--- a/securedrop_export/exceptions.py
+++ b/securedrop_export/exceptions.py
@@ -2,6 +2,18 @@ from enum import Enum
 
 
 class ExportStatus(Enum):
+    """
+    Status codes representing the results of export- and print-related
+    actions, such as searching for compatible print and export devices.
+
+    Codes may represent error/failure states (such as 'ERROR_USB_NOT_CONNECTED')
+    or success states (such as 'USB_CONNECTED').
+
+    These codes are reported back to the SecureDrop Client (sd-app) via RPC.
+
+    Warning: do not make changes to the existing values without
+    reviewing `securedrop-client/securedrop_client/export.py`.
+    """
 
     # General errors
     ERROR_FILE_NOT_FOUND = 'ERROR_FILE_NOT_FOUND'
@@ -11,13 +23,14 @@ class ExportStatus(Enum):
     ERROR_USB_CONFIGURATION = 'ERROR_USB_CONFIGURATION'
     ERROR_GENERIC = 'ERROR_GENERIC'
 
-    # USB preflight related errors
+    # USB preflight related
     USB_CONNECTED = 'USB_CONNECTED'
     USB_NOT_CONNECTED = 'USB_NOT_CONNECTED'
     ERROR_USB_CHECK = 'ERROR_USB_CHECK'
 
-    # USB Disk preflight related errors
+    # USB Disk preflight related
     USB_ENCRYPTED = 'USB_ENCRYPTED'
+    USB_ENCRYPTED_UNLOCKED = 'USB_ENCRYPTED_UNLOCKED'
     USB_ENCRYPTION_NOT_SUPPORTED = 'USB_ENCRYPTION_NOT_SUPPORTED'
     USB_DISK_ERROR = 'USB_DISK_ERROR'
 

--- a/tests/disk/test_actions.py
+++ b/tests/disk/test_actions.py
@@ -14,6 +14,13 @@ SAMPLE_OUTPUT_NO_PART = b"disk\ncrypt"  # noqa
 SAMPLE_OUTPUT_ONE_PART = b"disk\npart\ncrypt"  # noqa
 SAMPLE_OUTPUT_MULTI_PART = b"disk\npart\npart\npart\ncrypt"  # noqa
 SAMPLE_OUTPUT_USB = b"/dev/sda"  # noqa
+SAMPLE_LUKS_HEADER_SNIP = (b"LUKS header information\n" # noqa
+                           b"Version:\t2\n" # noqa
+                           b"Epoch:\t3\n" # noqa
+                           b"Metadata area:\t16634 [bytes]\n" # noqa
+                           b"Keyslots area:\t16744448 [bytes]\n" # noqa
+                           b"UUID:\t6ca4e6a6-bb05-43cd-9867-e233c8900aad\n" # noqa
+                           b"Label:\t(no label)\n") # noqa
 
 
 def test_usb_precheck_disconnected(capsys, mocker):
@@ -121,6 +128,7 @@ def test_extract_device_name_multiple_part(mocked_call, capsys, mocker):
     action = DiskExportAction(submission)
     action.device = "/dev/sda"
     mocked_exit = mocker.patch.object(submission, "exit_gracefully", return_value=0)
+
     expected_message = export.ExportStatus.USB_ENCRYPTION_NOT_SUPPORTED.value
 
     action.set_extracted_device_name()
@@ -149,6 +157,26 @@ def test_luks_precheck_encrypted_single_part(mocked_call, capsys, mocker):
     action = DiskExportAction(submission)
     action.device = "/dev/sda"
     expected_message = export.ExportStatus.USB_ENCRYPTED.value
+
+    mocked_exit = mocker.patch.object(submission, "exit_gracefully", return_value=0)
+
+    action.check_luks_volume()
+
+    mocked_exit.assert_called_once_with(expected_message)
+
+
+@mock.patch("subprocess.check_output", return_value=SAMPLE_OUTPUT_ONE_PART)
+@mock.patch("subprocess.check_call", return_value=0)
+def test_luks_precheck_encrypted_unlocked(mocked_call, capsys, mocker):
+    """
+    Test scenario where one LUKS-formatted USB drive is connected,
+    and it is already unlocked.
+    """
+    submission = export.SDExport("testfile", TEST_CONFIG)
+    action = DiskExportAction(submission)
+    action.device = "/dev/sdb"
+    expected_message = export.ExportStatus.USB_ENCRYPTED_UNLOCKED.value
+    mocker.patch.object(action, "_is_volume_unlocked", return_value=True)
     mocked_exit = mocker.patch.object(submission, "exit_gracefully", return_value=0)
 
     action.check_luks_volume()
@@ -201,3 +229,32 @@ def test_luks_precheck_encrypted_luks_error(mocked_call, capsys, mocker):
 
     assert mocked_exit.mock_calls[0][2]['msg'] == expected_message
     assert mocked_exit.mock_calls[0][2]['e'] is None
+
+
+@mock.patch("subprocess.check_output", return_value=SAMPLE_LUKS_HEADER_SNIP)
+def test__set_luks_device_name_success(mocked_call, capsys, mocker):
+    submission = export.SDExport("testfile", TEST_CONFIG)
+    action = DiskTestAction(submission)
+
+    # Device ID must match SAMPLE_LUKS_HEADER_SNIP
+    expected_device_id = "luks-6ca4e6a6-bb05-43cd-9867-e233c8900aad"
+
+    action._set_luks_device_name()
+    assert action.encrypted_device == expected_device_id
+
+
+@mock.patch("subprocess.check_output", side_effect=CalledProcessError(1, 'check_output'))
+def test__set_luks_device_name_failure(mocked_call, capsys, mocker):
+    submission = export.SDExport("testfile", TEST_CONFIG)
+    action = DiskTestAction(submission)
+    expected_message = "USB_ENCRYPTION_NOT_SUPPORTED"
+    # sanity check
+    assert expected_message == export.ExportStatus.USB_ENCRYPTION_NOT_SUPPORTED.value
+
+    mocked_exit = mocker.patch.object(submission, "exit_gracefully",
+                                      side_effect=lambda x: sys.exit(0))
+
+    with pytest.raises(SystemExit):
+        action._set_luks_device_name()
+
+    assert mocked_exit.mock_calls[0][1][0] == expected_message


### PR DESCRIPTION
If a user has unlocked their Export device (i.e. via the commandline or by opening Nautilus in sd-devices and inputting the passphrase), recognize that the drive is unlocked and don't ask again for passphrase before exporting documents.

Returns a status code from the disk checks run in sd-export (This will also enable us to incorporate other response/status codes, for example to distinguish between LUKS and Veracrypt devices, in future).

Note Changes must be tested with corresponding changes in sd-client and released together.

Fixes #40 (Together with corresponding sd-client PR https://github.com/freedomofpress/securedrop-client/pull/1462)
Towards https://github.com/freedomofpress/securedrop-workstation/issues/265