### PR TITLE
Treat ppdc warnings as non-fatal

### DIFF
--- a/securedrop_export/export.py
+++ b/securedrop_export/export.py
@@ -128,7 +128,13 @@ class SDExport(object):
         try:
             subprocess.check_call(command)
         except subprocess.CalledProcessError as ex:
-            self.exit_gracefully(msg=error_message, e=ex.output)
+            # ppdc emits warnings which should not be treated as user facing errors
+            if ex.returncode == 0 and \
+               ex.stderr is not None and \
+               ex.stderr.startswith("ppdc: Warning"):
+                logger.info('Encountered warning: {}'.format(ex.output))
+            else:
+                self.exit_gracefully(msg=error_message, e=ex.output)
 
 
 class ExportAction(abc.ABC):


### PR DESCRIPTION
Users have reported printers not working because of `ppdc` warning
messages reported in the client (asking them to contact an
administrator). These warnings do not result in non-zero return codes
and are seemingly really just warnings, so no need to get users
involved.

Fixes #51

# Testing

* Connect to workstation **HP LaserJet Pro M404n**
* Print a printable document
* [ ] Get to printing dialog without any errors/warnings