### PR TITLE
Use debian:buster CI image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,21 +1,23 @@
 ---
 common-steps:
-  - &removevirtualenv
+  - &install_deps
     run:
-      name: Removes the upstream virtualenv from the original container image
-      command: sudo pip uninstall virtualenv -y
-
+      name: Install base dependencies for Debian python
+      command: |
+        set -e
+        pip uninstall virtualenv -y || true
+        apt-get update && apt-get install -y sudo make git gnupg python3 python3-venv
   - &install_packages
     run:
       name: Install packages
       command: |
-        sudo apt install libnotify-bin
+        sudo apt install -y libnotify-bin
 
   - &run_tests
     run:
       name: Install test requirements and run tests
       command: |
-        virtualenv .venv
+        python3 -m venv .venv
         source .venv/bin/activate
         pip install --require-hashes -r requirements/dev-requirements.txt
         make check --keep-going
@@ -25,7 +27,8 @@ common-steps:
       name: Install Debian packaging dependencies and download wheels
       command: |
         mkdir ~/packaging && cd ~/packaging
-        git config --global --unset url.ssh://git@github.com.insteadof
+        # local builds may not have an SSH url
+        git config --global --unset url.ssh://git@github.com.insteadof || true
         git clone https://github.com/freedomofpress/securedrop-debian-packaging.git
         cd securedrop-debian-packaging
         make install-deps
@@ -54,20 +57,21 @@ common-steps:
       command: |
         cd ~/packaging/securedrop-debian-packaging
         export PKG_VERSION=1000.0
-        export PKG_PATH=/home/circleci/project/dist/securedrop-export-$PKG_VERSION.tar.gz
+        export PKG_PATH=~/project/dist/securedrop-export-$PKG_VERSION.tar.gz
         make securedrop-export
 
 version: 2
 jobs:
   lint:
     docker:
-      - image: circleci/python:3.7
+      - image: debian:buster
     steps:
+      - *install_deps
       - checkout
       - run:
           name: Install test requirements and run lint
           command: |
-            virtualenv .venv
+            python3 -m venv .venv
             source .venv/bin/activate
             pip install --require-hashes -r requirements/dev-requirements.txt
             make lint
@@ -80,18 +84,19 @@ jobs:
 
   test-buster:
     docker:
-      - image: circleci/python:3.7-buster
+      - image: debian:buster
     steps:
+      - *install_deps
       - checkout
       - *install_packages
       - *run_tests
 
   build-buster:
     docker:
-      - image: circleci/python:3.7-buster
+      - image: debian:buster
     steps:
+      - *install_deps
       - checkout
-      - *removevirtualenv
       - *install_packaging_dependencies
       - *verify_requirements
       - *make_source_tarball


### PR DESCRIPTION
Use debian buster CI image instead of python 3.7 image (see eg https://github.com/freedomofpress/securedrop-client/pull/1385)