### PR TITLE
Remove `.ppd` related logic and rely on CUPS to know how to print

### DIFF
--- a/securedrop_export/export.py
+++ b/securedrop_export/export.py
@@ -126,15 +126,7 @@ class SDExport(object):
         try:
             subprocess.check_call(command)
         except subprocess.CalledProcessError as ex:
-            # ppdc emits warnings which should not be treated as user facing errors
-            if (
-                ex.returncode == 0
-                and ex.stderr is not None
-                and ex.stderr.startswith("ppdc: Warning")
-            ):
-                logger.info("Encountered warning: {}".format(ex.output))
-            else:
-                self.exit_gracefully(msg=error_message, e=ex.output)
+            self.exit_gracefully(msg=error_message, e=ex.output)
 
 
 class ExportAction(abc.ABC):

--- a/tests/print/test_actions.py
+++ b/tests/print/test_actions.py
@@ -12,6 +12,7 @@ from securedrop_export.print.actions import PrintExportAction
 SAMPLE_OUTPUT_NO_PRINTER = b"network beh\nnetwork https\nnetwork ipp\nnetwork ipps\nnetwork http\nnetwork\nnetwork ipp14\nnetwork lpd"  # noqa
 SAMPLE_OUTPUT_BROTHER_PRINTER = b"network beh\nnetwork https\nnetwork ipp\nnetwork ipps\nnetwork http\nnetwork\nnetwork ipp14\ndirect usb://Brother/HL-L2320D%20series?serial=A00000A000000\nnetwork lpd"  # noqa
 SAMPLE_OUTPUT_LASERJET_PRINTER = b"network beh\nnetwork https\nnetwork ipp\nnetwork ipps\nnetwork http\nnetwork\nnetwork ipp14\ndirect usb://HP/LaserJet%20Pro%20M404-M405?serial=A00000A000000\nnetwork lpd"  # noqa
+SAMPLE_OUTPUT_NOT_SUPPORTED_PRINTER = b"network beh\nnetwork https\nnetwork ipp\nnetwork ipps\nnetwork http\nnetwork\nnetwork ipp14\ndirect usb://Not/Supported?serial=A00000A000000\nnetwork lpd"  # noqa
 TEST_CONFIG = os.path.join(os.path.dirname(__file__), "sd-export-config.json")
 
 
@@ -40,6 +41,22 @@ def test_get_bad_printer_uri(mocked_call, capsys, mocker):
     action = PrintExportAction(submission)
     expected_message = "ERROR_PRINTER_NOT_FOUND"
     assert export.ExportStatus.ERROR_PRINTER_NOT_FOUND.value == expected_message
+    mocked_exit = mocker.patch.object(
+        submission, "exit_gracefully", side_effect=lambda x: sys.exit(0)
+    )
+
+    with pytest.raises(SystemExit):
+        action.get_printer_uri()
+
+    mocked_exit.assert_called_once_with(expected_message)
+
+
+@mock.patch("subprocess.check_output", return_value=SAMPLE_OUTPUT_NOT_SUPPORTED_PRINTER)
+def test_get_unsupported_printer_uri(mocked_call, capsys, mocker):
+    submission = export.SDExport("testfile", TEST_CONFIG)
+    action = PrintExportAction(submission)
+    expected_message = "ERROR_PRINTER_NOT_SUPPORTED"
+    assert export.ExportStatus.ERROR_PRINTER_NOT_SUPPORTED.value == expected_message
     mocked_exit = mocker.patch.object(
         submission, "exit_gracefully", side_effect=lambda x: sys.exit(0)
     )
@@ -80,55 +97,6 @@ def test_is_not_open_office_file(capsys, open_office_paths):
     assert not action.is_open_office_file(open_office_paths)
 
 
-@mock.patch("subprocess.check_call")
-def test_install_printer_ppd_laserjet(mocker):
-    submission = export.SDExport("testfile", TEST_CONFIG)
-    action = PrintExportAction(submission)
-    ppd = action.install_printer_ppd(
-        "usb://HP/LaserJet%20Pro%20M404-M405?serial=A00000A00000"
-    )
-    assert ppd == "/usr/share/cups/model/hp-laserjet_6l.ppd"
-
-
-@mock.patch("subprocess.check_call")
-def test_install_printer_ppd_brother(mocker):
-    submission = export.SDExport("testfile", TEST_CONFIG)
-    action = PrintExportAction(submission)
-    ppd = action.install_printer_ppd(
-        "usb://Brother/HL-L2320D%20series?serial=A00000A000000"
-    )
-    assert ppd == "/usr/share/cups/model/br7030.ppd"
-
-
-def test_install_printer_ppd_error_no_driver(mocker):
-    submission = export.SDExport("testfile", TEST_CONFIG)
-    action = PrintExportAction(submission)
-    mocked_exit = mocker.patch.object(submission, "exit_gracefully", return_value=0)
-    mocker.patch(
-        "subprocess.check_call", side_effect=CalledProcessError(1, "check_call")
-    )
-
-    action.install_printer_ppd(
-        "usb://HP/LaserJet%20Pro%20M404-M405?serial=A00000A000000"
-    )
-
-    assert mocked_exit.mock_calls[0][2]["msg"] == "ERROR_PRINTER_DRIVER_UNAVAILABLE"
-    assert mocked_exit.mock_calls[0][2]["e"] is None
-
-
-def test_install_printer_ppd_error_not_supported(mocker):
-    submission = export.SDExport("testfile", TEST_CONFIG)
-    action = PrintExportAction(submission)
-    mocked_exit = mocker.patch.object(submission, "exit_gracefully", return_value=0)
-    mocker.patch(
-        "subprocess.check_call", side_effect=CalledProcessError(1, "check_call")
-    )
-
-    action.install_printer_ppd("usb://Not/Supported?serial=A00000A000000")
-
-    assert mocked_exit.mock_calls[0][2]["msg"] == "ERROR_PRINTER_NOT_SUPPORTED"
-
-
 def test_setup_printer_error(mocker):
     submission = export.SDExport("testfile", TEST_CONFIG)
     action = PrintExportAction(submission)
@@ -139,7 +107,6 @@ def test_setup_printer_error(mocker):
 
     action.setup_printer(
         "usb://Brother/HL-L2320D%20series?serial=A00000A000000",
-        "/usr/share/cups/model/br7030.ppd",
     )
 
     assert mocked_exit.mock_calls[0][2]["msg"] == "ERROR_PRINTER_INSTALL"


### PR DESCRIPTION
On bullseye `lpadmin` complains that using drivers directly is deprecated,
hence we go with the flow and preemptively make sure we don't run into
this problem in the future.

This leaves printer model checks in place, but simultaneously lowers the
bar to support more printers in the future.

The change was tested with a HP LaserJet Pro M404n but *not* a Brother
HL-L2320D

Fixes #93

## Testing

### Part 1

- [ ] `make test` passes and the new `test_get_unsupported_printer_uri` is a reasonable replacement for the tests that were removed
- (Cross reference) Continue with [securedrop-debian-packaging#352](https://github.com/freedomofpress/securedrop-debian-packaging/pull/352)

### Part 2

- Connect printer, to start `sd-devices`
- Log into client, and attempt to print a document as before
- [ ] Printing the document succeeds