### PR TITLE
Always communicate error messages to clients

### DIFF
--- a/securedrop_export/export.py
+++ b/securedrop_export/export.py
@@ -102,18 +102,19 @@ class SDExport(object):
         solutions for mimetype handling, which we want to avoid.
         """
         logger.info("Exiting with message: {}".format(msg))
-        if not e:
+        if e:
+            logger.error("Captured exception output: {}".format(e.output))
+        try:
+            # If the file archive was extracted, delete before returning
+            if os.path.isdir(self.tmpdir):
+                shutil.rmtree(self.tmpdir)
+            # Do this after deletion to avoid giving the client two error messages in case of the
+            # block above failing
             sys.stderr.write(msg)
             sys.stderr.write("\n")
-        else:
-            try:
-                # If the file archive was extracted, delete before returning
-                if os.path.isdir(self.tmpdir):
-                    shutil.rmtree(self.tmpdir)
-                logger.error("{}:{}".format(msg, e.output))
-            except Exception as ex:
-                logger.error("Unhandled exception: {}".format(ex))
-                sys.stderr.write(ExportStatus.ERROR_GENERIC.value)
+        except Exception as ex:
+            logger.error("Unhandled exception: {}".format(ex))
+            sys.stderr.write(ExportStatus.ERROR_GENERIC.value)
         # exit with 0 return code otherwise the os will attempt to open
         # the file with another application
         sys.exit(0)

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -2,6 +2,8 @@ import os
 import subprocess  # noqa: F401
 import tempfile
 
+from unittest import mock
+
 import json
 import pytest
 import tarfile
@@ -426,16 +428,18 @@ def test_exit_gracefully_no_exception(capsys):
 
 def test_exit_gracefully_exception(capsys):
     submission = export.SDExport("testfile", TEST_CONFIG)
-    test_msg = "test"
+    test_msg = "ERROR_GENERIC"
 
     with pytest.raises(SystemExit) as sysexit:
-        submission.exit_gracefully(test_msg, e=Exception("BANG!"))
+        exception = mock.MagicMock()
+        exception.output = "BANG!"
+        submission.exit_gracefully(test_msg, e=exception)
 
     # A graceful exit means a return code of 0
     assert sysexit.value.code == 0
 
     captured = capsys.readouterr()
-    assert captured.err == export.ExportStatus.ERROR_GENERIC.value
+    assert captured.err.rstrip() == export.ExportStatus.ERROR_GENERIC.value
     assert captured.out == ""
 
 


### PR DESCRIPTION
Currently, `exit_gracefully` does not share the type of error with
the client if the `subprocess` exception that called the method captured any
output. This PR changes the current behaviour: users always see error messages we want them to see, and logs are populated in case of captured output.

Fixes #95

## Testing

As this is difficult to trigger "in the wild", I think the following is sufficient, but I'm open to switching to a more in-depth test plan that involves using the client and triggering an error with output deliberately:

- [ ] (Optional, it is more efficient tho) Merge locally with #97 and review simultaneously
- [ ] Make sure that the updated test is reasonable
- [ ] The test passes
- [ ] File export to USB devices operates as expected
- [ ] (Optional) Printing works as expected
