### PR TITLE
Handle subprocess stderr output in Python 3.9, treat `lpadmin` warnings as non-fatal

### DIFF
--- a/securedrop_export/export.py
+++ b/securedrop_export/export.py
@@ -118,23 +118,24 @@ class SDExport(object):
         # the file with another application
         sys.exit(0)
 
-    def safe_check_call(self, command, error_message):
+    def safe_check_call(self, command, error_message, ignore_stderr_startswith=None):
         """
         Safely wrap subprocess.check_output to ensure we always return 0 and
         log the error messages
         """
         try:
-            subprocess.check_call(command)
-        except subprocess.CalledProcessError as ex:
-            # ppdc emits warnings which should not be treated as user facing errors
-            if (
-                ex.returncode == 0
-                and ex.stderr is not None
-                and ex.stderr.startswith("ppdc: Warning")
-            ):
-                logger.info("Encountered warning: {}".format(ex.output))
+            err = subprocess.run(command, check=True, capture_output=True).stderr
+            # ppdc and lpadmin may emit warnings we are aware of which should not be treated as
+            # user facing errors
+            if ignore_stderr_startswith and err.startswith(ignore_stderr_startswith):
+                logger.info("Encountered warning: {}".format(err.decode("utf-8")))
+            elif err == b"":
+                # Nothing on stderr and returncode is 0, we're good
+                pass
             else:
-                self.exit_gracefully(msg=error_message, e=ex.output)
+                self.exit_gracefully(msg=error_message, e=err)
+        except subprocess.CalledProcessError as ex:
+            self.exit_gracefully(msg=error_message, e=ex.output)
 
 
 class ExportAction(abc.ABC):

--- a/securedrop_export/print/actions.py
+++ b/securedrop_export/print/actions.py
@@ -143,6 +143,7 @@ class PrintAction(ExportAction):
                     "/usr/share/cups/model/",
                 ],
                 error_message=ExportStatus.ERROR_PRINTER_DRIVER_UNAVAILABLE.value,
+                ignore_stderr_startswith=b"ppdc: Warning",
             )
 
         return printer_ppd
@@ -165,6 +166,7 @@ class PrintAction(ExportAction):
                 "allow:user",
             ],
             error_message=ExportStatus.ERROR_PRINTER_INSTALL.value,
+            ignore_stderr_startswith=b"lpadmin: Printer drivers",
         )
 
     def print_test_page(self):

--- a/tests/print/test_actions.py
+++ b/tests/print/test_actions.py
@@ -80,7 +80,7 @@ def test_is_not_open_office_file(capsys, open_office_paths):
     assert not action.is_open_office_file(open_office_paths)
 
 
-@mock.patch("subprocess.check_call")
+@mock.patch("subprocess.run")
 def test_install_printer_ppd_laserjet(mocker):
     submission = export.SDExport("testfile", TEST_CONFIG)
     action = PrintExportAction(submission)
@@ -90,7 +90,7 @@ def test_install_printer_ppd_laserjet(mocker):
     assert ppd == "/usr/share/cups/model/hp-laserjet_6l.ppd"
 
 
-@mock.patch("subprocess.check_call")
+@mock.patch("subprocess.run")
 def test_install_printer_ppd_brother(mocker):
     submission = export.SDExport("testfile", TEST_CONFIG)
     action = PrintExportAction(submission)
@@ -105,7 +105,7 @@ def test_install_printer_ppd_error_no_driver(mocker):
     action = PrintExportAction(submission)
     mocked_exit = mocker.patch.object(submission, "exit_gracefully", return_value=0)
     mocker.patch(
-        "subprocess.check_call", side_effect=CalledProcessError(1, "check_call")
+        "subprocess.run", side_effect=CalledProcessError(1, "run")
     )
 
     action.install_printer_ppd(
@@ -121,7 +121,7 @@ def test_install_printer_ppd_error_not_supported(mocker):
     action = PrintExportAction(submission)
     mocked_exit = mocker.patch.object(submission, "exit_gracefully", return_value=0)
     mocker.patch(
-        "subprocess.check_call", side_effect=CalledProcessError(1, "check_call")
+        "subprocess.run", side_effect=CalledProcessError(1, "run")
     )
 
     action.install_printer_ppd("usb://Not/Supported?serial=A00000A000000")
@@ -134,7 +134,7 @@ def test_setup_printer_error(mocker):
     action = PrintExportAction(submission)
     mocked_exit = mocker.patch.object(submission, "exit_gracefully", return_value=0)
     mocker.patch(
-        "subprocess.check_call", side_effect=CalledProcessError(1, "check_call")
+        "subprocess.run", side_effect=CalledProcessError(1, "run")
     )
 
     action.setup_printer(

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -515,10 +515,33 @@ def test_valid_encryption_config(capsys):
 def test_safe_check_call(capsys, mocker):
     submission = export.SDExport("testfile", TEST_CONFIG)
     submission.safe_check_call(["ls"], "this will work")
-    mocked_exit = mocker.patch.object(submission, "exit_gracefully", return_value=0)
     expected_message = "uh oh!!!!"
 
-    submission.safe_check_call(["ls", "kjdsfhkdjfh"], expected_message)
+    with pytest.raises(SystemExit) as sysexit:
+        submission.safe_check_call(["ls", "kjdsfhkdjfh"], expected_message)
 
-    assert mocked_exit.mock_calls[0][2]["msg"] == expected_message
-    assert mocked_exit.mock_calls[0][2]["e"] is None
+    assert sysexit.value.code == 0
+
+    captured = capsys.readouterr()
+    assert captured.err == "{}\n".format(expected_message)
+    assert captured.out == ""
+
+    # This should work too
+    submission.safe_check_call(
+        ["python3", "-c", "import sys;sys.stderr.write('hello')"],
+        expected_message,
+        ignore_stderr_startswith=b'hello',
+    )
+
+    with pytest.raises(SystemExit) as sysexit:
+        submission.safe_check_call(
+            ["python3", "-c", "import sys;sys.stderr.write('hello\n')"],
+            expected_message,
+            ignore_stderr_startswith=b'world',
+        )
+
+    assert sysexit.value.code == 0
+
+    captured = capsys.readouterr()
+    assert captured.err == "{}\n".format(expected_message)
+    assert captured.out == ""


### PR DESCRIPTION
As opposed to how it worked in Python 3.7, `subprocess.check_call` does not raise an exception anymore if there's output on stderr even when the returncode is 0. So we move on to the newer `subprocess` API that allows us to capture stderr and analyze it even if the returncode is 0.

This is necessary so we can safely ignore `lpadmin` warnings that would otherwise stop the printing process. This means that at least for now, we'll continue to use Debian supplied printer drivers with CUPS. However a change like #94 ought to be considered/tested in the future for the obvious benefit of not having to deal with printer drivers and easily supporting new printers.

Fixes #93

Towards https://github.com/freedomofpress/securedrop-workstation/issues/600

# Testing

To save on time, this PR may be reviewed at the same as #96.

- [ ] `make test` passes (`test-buster` CI is currently broken, may be safely ignored)
- [ ] Attempting to print without a printer asks for it to be connected
- [ ] Printing images, `.txt` files and `.docx` files with a supported printer connected is successful
- [ ] Export functionality behaves as expected
