### PR TITLE
Add RTF printing support

### DIFF
--- a/securedrop_export/print/actions.py
+++ b/securedrop_export/print/actions.py
@@ -194,6 +194,7 @@ class PrintAction(ExportAction):
             ".odt",
             ".ods",
             ".odp",
+            ".rtf",
         ]
         for extension in OPEN_OFFICE_FORMATS:
             if os.path.basename(filename).endswith(extension):


### PR DESCRIPTION
Merely adds `.rtf` to the file name extensions that are to be converted by LibreOffice.

Fixes #108

# Testing

- Submit an `.rtf` file that contains a bunch of formatting etc. to your test instance 
- After downloading said file in the client, print it!
- [ ] Resulting printout does not contain any RTF markup but is an accurate reflection of the documented that was submitted