### PR TITLE
Fix: imports/namespacing

### DIFF
--- a/securedrop_export/disk/__init__.py
+++ b/securedrop_export/disk/__init__.py
@@ -1,1 +1,1 @@
-from .service import Service  # noqa: F401
+from .legacy_service import Service as LegacyService  # noqa: F401

--- a/securedrop_export/main.py
+++ b/securedrop_export/main.py
@@ -10,7 +10,7 @@ from securedrop_export.status import BaseStatus
 from securedrop_export.directory import safe_mkdir
 from securedrop_export.exceptions import ExportException
 
-from securedrop_export.disk import Service as ExportService
+from securedrop_export.disk import LegacyService as ExportService
 from securedrop_export.print import Service as PrintService
 
 from logging.handlers import TimedRotatingFileHandler, SysLogHandler


### PR DESCRIPTION
Bugfix, introduced by renaming of service files. mea culpa!

**Test plan (I have stepped through)**
- [x] put builder script in a clean build enviroment (eg debian vm)
- [x] clone sd-bullseye-large
- [x] `./builder.sh securedrop-export 119` and install the deb in your cloned template, above
- [x] assign cloned template as template for sd-devices-dvm
- [x] shut down all, then start the client and run acceptance tests. Observe tests passing, no errors in logs.