### PR TITLE
Bump certifi dev dependency due to removal of root certificate

### DIFF
--- a/requirements/dev-bookworm-requirements.in
+++ b/requirements/dev-bookworm-requirements.in
@@ -2,6 +2,7 @@
 -r requirements.in
 
 black
+certifi>=2023.07.22
 flake8
 pip-tools
 pytest

--- a/requirements/dev-bookworm-requirements.txt
+++ b/requirements/dev-bookworm-requirements.txt
@@ -51,10 +51,12 @@ build==0.10.0 \
     --hash=sha256:af266720050a66c893a6096a2f410989eeac74ff9a68ba194b3f6473e8e26171 \
     --hash=sha256:d5b71264afdb5951d6704482aac78de887c80691c52b88a9ad195983ca2c9269
     # via pip-tools
-certifi==2023.5.7 \
-    --hash=sha256:0f0d56dc5a6ad56fd4ba36484d6cc34451e1c6548c61daad8c320169f91eddc7 \
-    --hash=sha256:c6c2e98f5c7869efca1f8916fed228dd91539f9f1b444c314c06eef02980c716
-    # via requests
+certifi==2023.7.22 \
+    --hash=sha256:539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082 \
+    --hash=sha256:92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9
+    # via
+    #   -r requirements/dev-bookworm-requirements.in
+    #   requests
 charset-normalizer==3.2.0 \
     --hash=sha256:04e57ab9fbf9607b77f7d057974694b4f6b142da9ed4a199859d9d4d5c63fe96 \
     --hash=sha256:09393e1b2a9461950b1c9a45d5fd251dc7c6f228acab64da1c9c0165d9c7765c \

--- a/requirements/dev-bullseye-requirements.in
+++ b/requirements/dev-bullseye-requirements.in
@@ -2,6 +2,7 @@
 -r requirements.in
 
 black
+certifi>=2023.07.22
 flake8
 pip-tools
 pytest

--- a/requirements/dev-bullseye-requirements.txt
+++ b/requirements/dev-bullseye-requirements.txt
@@ -51,10 +51,12 @@ build==0.10.0 \
     --hash=sha256:af266720050a66c893a6096a2f410989eeac74ff9a68ba194b3f6473e8e26171 \
     --hash=sha256:d5b71264afdb5951d6704482aac78de887c80691c52b88a9ad195983ca2c9269
     # via pip-tools
-certifi==2023.5.7 \
-    --hash=sha256:0f0d56dc5a6ad56fd4ba36484d6cc34451e1c6548c61daad8c320169f91eddc7 \
-    --hash=sha256:c6c2e98f5c7869efca1f8916fed228dd91539f9f1b444c314c06eef02980c716
-    # via requests
+certifi==2023.7.22 \
+    --hash=sha256:539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082 \
+    --hash=sha256:92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9
+    # via
+    #   -r requirements/dev-bullseye-requirements.in
+    #   requests
 charset-normalizer==3.2.0 \
     --hash=sha256:04e57ab9fbf9607b77f7d057974694b4f6b142da9ed4a199859d9d4d5c63fe96 \
     --hash=sha256:09393e1b2a9461950b1c9a45d5fd251dc7c6f228acab64da1c9c0165d9c7765c \


### PR DESCRIPTION
- Fixes https://github.com/freedomofpress/securedrop-export/security/dependabot/6
- Fixes https://github.com/freedomofpress/securedrop-export/security/dependabot/7